### PR TITLE
List Riemann as a dev dependency only

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,8 @@
   :url "https://github.com/exoscale/riemann-acknowledgement"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :profiles {:dev {:dependencies [[riemann "0.2.6"]]}}
   :dependencies [[org.clojure/clojure       "1.5.1"]
                  [compojure                 "1.1.6"]
                  [ring/ring-json            "0.2.0"]
-                 [javax.servlet/servlet-api "2.5"]
-                 [riemann                   "0.2.4"
-                  :exclusions [org.slf4j/slf4j-log4j12]]])
+                 [javax.servlet/servlet-api "2.5"]])


### PR DESCRIPTION
List Riemann as a dev dependency only to prevent it from being included
in the uberjar. It is not necessary because the Riemann jar will be
present from the Riemann installation.

Removing Riemann from the uberjar will help shrink the size of the
uberjar, and will allow it to be used with other versions of Riemann. If
Riemann is left in the uberjar, the classes in the plugin will override
those in the Riemann jar itself. This caused problems for me where functions introduced in newer versions of Riemann are unavailable because the Riemann classes used were the ones from the riemann-acknowledge uberjar rather than from the riemann jar itself.
